### PR TITLE
Fix default storage return value

### DIFF
--- a/src/utils/storage-available.ts
+++ b/src/utils/storage-available.ts
@@ -14,7 +14,7 @@ export function localStorageAvailable() {
 export function localStorageGetItem(key: string, defaultValue = '') {
   const storageAvailable = localStorageAvailable();
 
-  let value;
+  let value = defaultValue;
 
   if (storageAvailable) {
     value = localStorage.getItem(key) || defaultValue;


### PR DESCRIPTION
## Summary
- ensure a fallback value if localStorage is unavailable

## Testing
- `npm run ts` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68499283f590832cb5fe03dc03cb1965