### PR TITLE
Implement alert marker enhancements

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -81,3 +81,18 @@ input[type='number']::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
 }
+
+.marker-wrapper {
+  position: relative;
+  display: inline-block;
+}
+.marker-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: red;
+  color: white;
+  border-radius: 50%;
+  padding: 2px 4px;
+  font-size: 10px;
+}

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -1,0 +1,30 @@
+export function playBeep(duration = 500, frequency = 440) {
+  const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
+  const ctx = new AudioCtx();
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'sine';
+  osc.frequency.value = frequency;
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start();
+  osc.stop(ctx.currentTime + duration / 1000);
+  osc.onended = () => ctx.close();
+}
+
+export function playSiren() {
+  const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
+  const ctx = new AudioCtx();
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'sawtooth';
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  const duration = 1.5;
+  osc.frequency.setValueAtTime(600, ctx.currentTime);
+  osc.frequency.linearRampToValueAtTime(1200, ctx.currentTime + duration / 2);
+  osc.frequency.linearRampToValueAtTime(600, ctx.currentTime + duration);
+  osc.start();
+  osc.stop(ctx.currentTime + duration);
+  osc.onended = () => ctx.close();
+}

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,0 +1,12 @@
+export function distanceKm(a: [number, number], b: [number, number]) {
+  const R = 6371; // Earth radius in km
+  const toRad = (v: number) => (v * Math.PI) / 180;
+  const dLat = toRad(b[0] - a[0]);
+  const dLon = toRad(b[1] - a[1]);
+  const lat1 = toRad(a[0]);
+  const lat2 = toRad(b[0]);
+  const h =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  return 2 * R * Math.asin(Math.sqrt(h));
+}


### PR DESCRIPTION
## Summary
- show unapproved alerts to their creator with opacity
- group nearby alerts for admin and display count badge
- play siren or beep when an alert near the user is approved
- serve user-specific markers from server
- add helper utilities for audio playback and distance calculations

## Testing
- `npm run ts` *(fails: Property errors in theme components)*

------
https://chatgpt.com/codex/tasks/task_e_6860c17519f4832c9e8d60fb5bf3a523